### PR TITLE
Make it so that if the text prop changes, the component is re-rendered

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -65,6 +65,12 @@ class InlineEdit extends React.Component {
         })
     }
 
+    componentWillReceiveProps(nextProps) {
+        if(nextProps.text !== this.state.text) {
+            this.setState({ text: nextProps.text });
+        }
+    }
+
     componentDidUpdate(prevProps, prevState) {
         var inputElem = ReactDOM.findDOMNode(this.refs.input);
         if (this.state.editing && !prevState.editing) {
@@ -72,12 +78,6 @@ class InlineEdit extends React.Component {
             SelectInputText(inputElem);
         } else if (this.state.editing && prevProps.text != this.props.text) {
             this.finishEditing();
-        }
-    }
-
-    componentWillReceiveProps(nextProps) {
-        if(nextProps.text !== this.state.text) {
-            this.setState({ text: nextProps.text });
         }
     }
 

--- a/index.jsx
+++ b/index.jsx
@@ -75,6 +75,12 @@ class InlineEdit extends React.Component {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+        if(nextProps.text !== this.state.text) {
+            this.setState({ text: nextProps.text });
+        }
+    }
+
     render() {
         if(!this.state.editing) {
             return <span className={this.props.className} onClick={this.startEditing}>{this.state.text || this.props.placeholder}</span>


### PR DESCRIPTION
My use case for this was I had a list of items and when you clicked on one of those items, their data would be loaded into a form that used ReactInlineEdit. ReactInlineEdit didn't handle the `text` prop being changed after it had been mounted. My PR simply adds a `componentWillReceiveProps` method that invokes `setState` with the new `props.text` so that the component is up to date with the new data. 

Let me know if this works for you, I'd be happy to make any additional changes. Also, I had trouble getting the build to work on my machine so I opted to not mess with that entirely and leave it up to you to build it if you decide to accept this PR. :smiley_cat: 