### PR TITLE
Fix rerender bug

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -257,7 +257,7 @@
 	    }, {
 	        key: 'componentWillReceiveProps',
 	        value: function componentWillReceiveProps(nextProps) {
-	            if (nextProps.text !== this.state.text) {
+	            if (nextProps.text !== this.props.text) {
 	                this.setState({ text: nextProps.text });
 	            }
 	        }

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ var InlineEdit = function (_React$Component) {
     }, {
         key: 'componentWillReceiveProps',
         value: function componentWillReceiveProps(nextProps) {
-            if (nextProps.text !== this.state.text) {
+            if (nextProps.text !== this.props.text) {
                 this.setState({ text: nextProps.text });
             }
         }

--- a/index.jsx
+++ b/index.jsx
@@ -46,7 +46,7 @@ export default class InlineEdit extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.text !== this.state.text) {
+        if (nextProps.text !== this.props.text) {
             this.setState({ text: nextProps.text });
         }
     }


### PR DESCRIPTION
Fix bug introduced in #6.

Reproduce: 

1- Set prop `text="sometext"`
2- Click on component to edit, type text and change it to "othertext".
3- Update any other prop, e.g. className, or [any other reason componentWillReceiveProps is called](https://facebook.github.io/react/blog/2016/01/08/A-implies-B-does-not-imply-B-implies-A.html)
4- The text will return to being "sometext"

The component always updates state.text to be equal to prop.text whenever any prop is changed and the state.text was changed at any point. We should only update the text when we change the text prop itself.

cc @ccnokes 