### PR TITLE
Add stopPropagation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Watch a [demo](https://cdn.rawgit.com/kaivi/ReactInlineEdit/master/demo/index.ht
 - `editingElement`:_string_ element name to use when in edit mode (DOM must have `value` property) **default** `input`
 - `staticElement`:_string_ element name for displaying data **default** `span`
 - `tabIndex`:_number_ tab index used for focusing with TAB key **default** `0`
+- `stopPropagation`:_boolean_ If true, the event onClick will not be further propagated.
 
 ### Usage example
 ```javascript

--- a/demo/index.js
+++ b/demo/index.js
@@ -215,7 +215,10 @@
 	            text: _this.props.text,
 	            minLength: _this.props.minLength,
 	            maxLength: _this.props.maxLength
-	        }, _this.startEditing = function () {
+	        }, _this.startEditing = function (e) {
+	            if (_this.props.stopPropagation) {
+	                e.stopPropagation();
+	            }
 	            _this.setState({ editing: true, text: _this.props.text });
 	        }, _this.finishEditing = function () {
 	            if (_this.isInputValid(_this.state.text) && _this.props.text != _this.state.text) {
@@ -230,6 +233,10 @@
 	            var newProp = {};
 	            newProp[_this.props.paramName] = _this.state.text;
 	            _this.props.change(newProp);
+	        }, _this.clickWhenEditing = function (e) {
+	            if (_this.props.stopPropagation) {
+	                e.stopPropagation();
+	            }
 	        }, _this.isInputValid = function (text) {
 	            return text.length >= _this.state.minLength && text.length <= _this.state.maxLength;
 	        }, _this.keyDown = function (event) {
@@ -285,6 +292,7 @@
 	            } else {
 	                var Element = this.props.element || this.props.editingElement;
 	                return _react2.default.createElement(Element, {
+	                    onClick: this.clickWhenEditing,
 	                    onKeyDown: this.keyDown,
 	                    onBlur: this.finishEditing,
 	                    className: this.props.activeClassName,

--- a/index.js
+++ b/index.js
@@ -45,7 +45,10 @@ var InlineEdit = function (_React$Component) {
             text: _this.props.text,
             minLength: _this.props.minLength,
             maxLength: _this.props.maxLength
-        }, _this.startEditing = function () {
+        }, _this.startEditing = function (e) {
+            if (_this.props.stopPropagation) {
+                e.stopPropagation();
+            }
             _this.setState({ editing: true, text: _this.props.text });
         }, _this.finishEditing = function () {
             if (_this.isInputValid(_this.state.text) && _this.props.text != _this.state.text) {
@@ -60,6 +63,10 @@ var InlineEdit = function (_React$Component) {
             var newProp = {};
             newProp[_this.props.paramName] = _this.state.text;
             _this.props.change(newProp);
+        }, _this.clickWhenEditing = function (e) {
+            if (_this.props.stopPropagation) {
+                e.stopPropagation();
+            }
         }, _this.isInputValid = function (text) {
             return text.length >= _this.state.minLength && text.length <= _this.state.maxLength;
         }, _this.keyDown = function (event) {
@@ -119,6 +126,7 @@ var InlineEdit = function (_React$Component) {
             } else {
                 var Element = this.props.element || this.props.editingElement;
                 return _react2.default.createElement(Element, {
+                    onClick: this.clickWhenEditing,
                     onKeyDown: this.keyDown,
                     onBlur: this.finishEditing,
                     className: this.props.activeClassName,

--- a/index.jsx
+++ b/index.jsx
@@ -61,7 +61,10 @@ export default class InlineEdit extends React.Component {
         }
     }
 
-    startEditing = () => {
+    startEditing = (e) => {
+        if (this.props.stopPropagation) {
+            e.stopPropagation()
+        }
         this.setState({editing: true, text: this.props.text});
     };
 
@@ -82,6 +85,12 @@ export default class InlineEdit extends React.Component {
         let newProp = {};
         newProp[this.props.paramName] = this.state.text;
         this.props.change(newProp);
+    };
+
+    clickWhenEditing = (e) => {
+        if (this.props.stopPropagation) {
+            e.stopPropagation();
+        }
     };
 
     isInputValid = (text) => {
@@ -115,6 +124,7 @@ export default class InlineEdit extends React.Component {
         } else {
             const Element = this.props.element || this.props.editingElement;
             return <Element
+                onClick={this.clickWhenEditing}
                 onKeyDown={this.keyDown}
                 onBlur={this.finishEditing}
                 className={this.props.activeClassName}


### PR DESCRIPTION
This happens in my project that an ``InlineEdit`` is embedded in another DOM object that also responds to ``onClick`` events (technically, embedded in the title of a collapsible panel), and it is not desirable that clicking ``InlineEdit`` triggers the event of the container. 

By adding this option, users can choose to stop the ``onClick`` event from further propagating.