### PR TITLE
Update peer dependencies to allow React 15.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/kaivi/ReactInlineEdit#readme",
   "peerDependencies": {
-    "react": "^0.14.6"
+    "react": "^0.14.6 || 15.x.x"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",


### PR DESCRIPTION
Updated peer dependencies to allow both react 0.14 and react 15