### PR TITLE
remove onReturn props From Element #24

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -150,7 +150,6 @@ export default class InlineEdit extends React.Component {
                 className={this.props.activeClassName}
                 placeholder={this.props.placeholder}
                 defaultValue={this.state.text}
-                onReturn={this.finishEditing}
                 onChange={this.textChanged}
                 style={this.props.style}
                 ref="input" />;


### PR DESCRIPTION
right now 'Element' tag is a span or an input .
As far as I know, Both of those element does not accept an 'onReturn' props, so to fix #24 I've just removed this