### PR TITLE
isTextChange should compare between this.state.text with this.props.text

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -21,7 +21,9 @@ export default class InlineEdit extends React.Component {
         staticElement: React.PropTypes.string,
         tabIndex: React.PropTypes.number,
         isDisabled: React.PropTypes.bool,
-        editing: React.PropTypes.bool
+        editing: React.PropTypes.bool,
+        onStartEditing: React.PropTypes.function,
+        onFinishEditing: React.PropTypes.function,
     };
 
     static defaultProps = {
@@ -78,6 +80,10 @@ export default class InlineEdit extends React.Component {
         if (this.props.stopPropagation) {
             e.stopPropagation()
         }
+
+        if (this.props.onStartEditing)
+          this.props.onStartEditing();
+
         this.setState({editing: true, text: this.props.text});
     };
 
@@ -87,6 +93,9 @@ export default class InlineEdit extends React.Component {
         } else if (this.props.text === this.state.text || !this.isInputValid(this.state.text)) {
             this.cancelEditing();
         }
+
+        if (this.props.onFinishEditing)
+          this.props.onFinishEditing();
     };
 
     cancelEditing = () => {

--- a/index.jsx
+++ b/index.jsx
@@ -50,7 +50,7 @@ export default class InlineEdit extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        const isTextChanged = (nextProps.text !== this.props.text);
+        const isTextChanged = (this.state.text !== this.props.text);
         const isEditingChanged = (nextProps.editing !== this.props.editing);
         let nextState = {};
         if (isTextChanged) {


### PR DESCRIPTION
When a user's already changed text then we pass text to this class as props, it should be changed to a text that we passed. (even if it's same as previous text)

So isTextChange should compare between this.state.text with this.props.text.

And also we should able to pass functions onStartEditing and onFinishEditing as props to be
called when a user starts and finishes editing.
That makes we can do something, when we click away from the text area. (issue #28)