### PR TITLE
add size attribute to input

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,6 +153,7 @@ var InlineEdit = function (_React$Component) {
                     onReturn: this.finishEditing,
                     onChange: this.textChanged,
                     style: this.props.style,
+                    size: this.props.text.length + 2,
                     ref: 'input' });
             }
         }
@@ -172,6 +173,7 @@ InlineEdit.propTypes = {
     maxLength: _react2.default.PropTypes.number,
     validate: _react2.default.PropTypes.func,
     style: _react2.default.PropTypes.object,
+    size: _react2.default.PropTypes.number,
     editingElement: _react2.default.PropTypes.string,
     staticElement: _react2.default.PropTypes.string,
     tabIndex: _react2.default.PropTypes.number,


### PR DESCRIPTION
With this fix input size should auto expand (shrink) depends on text length. I increased original text.length value on 2 to reserve a little space. If use original value in some cases text do not fit into input. 

I've used this approach in my personal project. Didn't test within this repo, please test it first...