### PR TITLE
switch to standalone prop-types instead of from react

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 
 function selectInputText(element) {
     element.setSelectionRange(0, element.value.length);
@@ -7,21 +8,21 @@ function selectInputText(element) {
 
 export default class InlineEdit extends React.Component {
     static propTypes = {
-        text: React.PropTypes.string.isRequired,
-        paramName: React.PropTypes.string.isRequired,
-        change: React.PropTypes.func.isRequired,
-        placeholder: React.PropTypes.string,
-        className: React.PropTypes.string,
-        activeClassName: React.PropTypes.string,
-        minLength: React.PropTypes.number,
-        maxLength: React.PropTypes.number,
-        validate: React.PropTypes.func,
-        style: React.PropTypes.object,
-        editingElement: React.PropTypes.string,
-        staticElement: React.PropTypes.string,
-        tabIndex: React.PropTypes.number,
-        isDisabled: React.PropTypes.bool,
-        editing: React.PropTypes.bool
+        text: PropTypes.string.isRequired,
+        paramName: PropTypes.string.isRequired,
+        change: PropTypes.func.isRequired,
+        placeholder: PropTypes.string,
+        className: PropTypes.string,
+        activeClassName: PropTypes.string,
+        minLength: PropTypes.number,
+        maxLength: PropTypes.number,
+        validate: PropTypes.func,
+        style: PropTypes.object,
+        editingElement: PropTypes.string,
+        staticElement: PropTypes.string,
+        tabIndex: PropTypes.number,
+        isDisabled: PropTypes.bool,
+        editing: PropTypes.bool
     };
 
     static defaultProps = {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   },
   "homepage": "https://github.com/kaivi/ReactInlineEdit#readme",
   "peerDependencies": {
-    "react": "^0.14.6 || 15.x.x"
+    "react": "^0.14.6 || 15.x.x",
+    "prop-types": "^15.6.2"
+
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",


### PR DESCRIPTION
This package breaks in newer versions of react because it expect `PropTypes` on the `React` object, this change allows it to use a peer dependency of `prop-type` directly